### PR TITLE
Adding Android as a Supported Platform

### DIFF
--- a/GraphicsToolsProject/Config/DefaultEngine.ini
+++ b/GraphicsToolsProject/Config/DefaultEngine.ini
@@ -143,3 +143,7 @@ GlobalDefaultServerGameMode=None
 [/Script/Slate.SlateSettings]
 bExplicitCanvasChildZOrder=True
 
+[/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]
+PackageName=com.Microsoft.GraphicsToolsProject
+bPackageDataInsideApk=True
+

--- a/GraphicsToolsProject/Plugins/GraphicsTools/GraphicsTools.uplugin
+++ b/GraphicsToolsProject/Plugins/GraphicsTools/GraphicsTools.uplugin
@@ -17,7 +17,8 @@
 	"Installed": false,
 	"SupportedTargetPlatforms": [
 		"Win64",
-		"HoloLens"
+		"HoloLens",
+		"Android"
 	],
 	"Modules": [
 		{
@@ -26,7 +27,8 @@
 			"LoadingPhase": "PostConfigInit",
 			"WhitelistPlatforms": [
 				"Win64",
-				"HoloLens"
+				"HoloLens",
+				"Android"
 			]
 		},
 		{

--- a/GraphicsToolsProject/Plugins/GraphicsTools/Shaders/Common/GTCommon.ush
+++ b/GraphicsToolsProject/Plugins/GraphicsTools/Shaders/Common/GTCommon.ush
@@ -4,12 +4,33 @@
 #ifndef GT_COMMON
 #define GT_COMMON
 
+// Defines mirrored from https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Shaders/Public/FP16Math.ush
+#ifndef EXPERIMENTAL_FP16
+#define EXPERIMENTAL_FP16 1
+#endif
+
+#ifndef USE_MIN16FLOAT
+#define USE_MIN16FLOAT 0
+#endif
+
+#if EXPERIMENTAL_FP16
+#if USE_MIN16FLOAT
 #define Half min16float
 #define Half2 min16float2
 #define Half3 min16float3
 #define Half4 min16float4
-#define Half3x3 min16float3x3
-#define Half3x4 min16float3x4
+#else
+#define Half half
+#define Half2 half2
+#define Half3 half3
+#define Half4 half4
+#endif
+#else
+#define Half float
+#define Half2 float2
+#define Half3 float3
+#define Half4 float4
+#endif
 
 #define GT_PI Half(3.14159265359)
 #define GT_ONE_OVER_PI Half(1.0) / GT_PI

--- a/GraphicsToolsProject/Plugins/GraphicsToolsExamples/GraphicsToolsExamples.uplugin
+++ b/GraphicsToolsProject/Plugins/GraphicsToolsExamples/GraphicsToolsExamples.uplugin
@@ -17,7 +17,8 @@
 	"Installed": false,
 	"SupportedTargetPlatforms": [
 		"Win64",
-		"HoloLens"
+		"HoloLens",
+		"Android"
 	],
 	"Modules": [
 		{

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Graphics Tools for Unreal Engine is a UE game plugin with code, blueprints and example assets created to help improve the visual fidelity of Mixed Reality applications while staying within performance budgets.
 
-| NOTE: Only HoloLens 2 development is supported at the moment. |
+| NOTE: Only HoloLens 2, Windows, and Android development is tested at the moment. If you encounter issues with other platforms please [file an issue](https://github.com/microsoft/MixedReality-GraphicsTools-Unreal/issues/new). |
 | --- |
 
 ![Features](Docs/Images/Features.png)


### PR DESCRIPTION
Android is now a supported target platform for the Graphics Tools & Graphics Tools Examples plugin. This PR primary fixes #6  around half precision floats.

Screenshot from a Samsung Galaxy S20 5G:
![Screenshot_20210713-101713_GraphicsToolsProject](https://user-images.githubusercontent.com/13305729/125499021-1cc9adb3-e7ad-4a51-9ded-92a4bff084bd.jpg)
