### PR TITLE
Fix CI pipelines

### DIFF
--- a/EditorVersion.json
+++ b/EditorVersion.json
@@ -1,0 +1,5 @@
+{
+    "name": "ue.4.26.win",
+    "package": "26.0.7",
+    "comment": "Unreal Engine 4.26.0 official release"
+}

--- a/EditorVersion.json
+++ b/EditorVersion.json
@@ -1,5 +1,5 @@
 {
     "name": "ue.4.26.win",
-    "package": "26.0.7",
-    "comment": "Unreal Engine 4.26.0 official release"
+    "package": "26.2.0",
+    "comment": "Unreal Engine 4.26.2 official release"
 }

--- a/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Private/GTClippingBoxComponent.cpp
+++ b/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Private/GTClippingBoxComponent.cpp
@@ -5,6 +5,8 @@
 
 #include "GTWorldSubsystem.h"
 
+#include "Engine/World.h"
+
 UGTClippingBoxComponent::UGTClippingBoxComponent()
 {
 	{

--- a/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Private/GTClippingConeComponent.cpp
+++ b/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Private/GTClippingConeComponent.cpp
@@ -5,6 +5,8 @@
 
 #include "GTWorldSubsystem.h"
 
+#include "Engine/World.h"
+
 UGTClippingConeComponent::UGTClippingConeComponent()
 {
 	{

--- a/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Private/GTClippingSphereComponent.cpp
+++ b/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Private/GTClippingSphereComponent.cpp
@@ -5,6 +5,8 @@
 
 #include "GTWorldSubsystem.h"
 
+#include "Engine/World.h"
+
 UGTClippingSphereComponent::UGTClippingSphereComponent()
 {
 	{

--- a/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Private/GTVisualProfiler.cpp
+++ b/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Private/GTVisualProfiler.cpp
@@ -5,8 +5,11 @@
 
 #include "GraphicsTools.h"
 
+#include "Camera/PlayerCameraManager.h"
 #include "Components/StaticMeshComponent.h"
 #include "Components/TextRenderComponent.h"
+#include "Engine/StaticMesh.h"
+#include "GameFramework/PlayerController.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "UObject/ConstructorHelpers.h"
 

--- a/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Public/GTVisualProfiler.h
+++ b/GraphicsToolsProject/Plugins/GraphicsTools/Source/GraphicsTools/Public/GTVisualProfiler.h
@@ -9,6 +9,7 @@
 
 #include "GTVisualProfiler.generated.h"
 
+class UMaterial;
 class UStaticMeshComponent;
 class UTextRenderComponent;
 

--- a/Tools/CI/ci.yml
+++ b/Tools/CI/ci.yml
@@ -1,5 +1,9 @@
+# Automatic CI validation. Does not run on PRs.
+pr: none
 trigger:
 - main
+- public/*
+
 
 variables:
 - template: settings/common.yml

--- a/Tools/CI/ci.yml
+++ b/Tools/CI/ci.yml
@@ -4,7 +4,6 @@ trigger:
 - main
 - public/*
 
-
 variables:
 - template: settings/common.yml
 

--- a/Tools/CI/settings/common.yml
+++ b/Tools/CI/settings/common.yml
@@ -1,6 +1,6 @@
 variables:
   AgentPool: UXT-UE
-  SourceDir: $(Build.SourcesDirectory)/$(Build.Repository.Name)
+  SourceDir: $(Build.SourcesDirectory)/MixedReality-GraphicsTools-Unreal # $(Build.Repository.Name) for a GitHub repo adds the organization as a prefix, which does not match the folder name on disk.
   ToolsDir: $(Build.SourcesDirectory)/mixedrealitytoolkit.build
   ClangFormat.Version: 11.0.0
   GraphicsToolsProjectDir: $(SourceDir)/GraphicsToolsProject

--- a/Tools/CI/ship.yml
+++ b/Tools/CI/ship.yml
@@ -1,4 +1,5 @@
-# Manually triggered pipeline to generate shipping builds of the CI artifacts
+# Manually triggered pipeline to generate shipping builds of the CI artifacts.
+pr: none
 trigger: none
 
 variables:

--- a/Tools/CI/templates/common.yml
+++ b/Tools/CI/templates/common.yml
@@ -56,7 +56,7 @@ steps:
   displayName: 'Build GraphicsTools'
   inputs:
     filePath: $(SourceDir)/Tools/scripts/BuildPlugin.ps1
-    arguments: -UnrealEngine $(UnrealEngine) -PluginDir $(GraphicsToolsPluginDir)/GraphicsTools.uplugin -PackageOutDir $(GraphicsToolsBuildDir)
+    arguments: -UnrealEngine $(UnrealEngine) -PluginPath $(GraphicsToolsPluginDir)/GraphicsTools.uplugin -PackageOutDir $(GraphicsToolsBuildDir)
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish GraphicsTools to build artifacts'
@@ -75,7 +75,7 @@ steps:
   displayName: 'Build GraphicsToolsExamples'
   inputs:
     filePath: $(SourceDir)/Tools/scripts/BuildPlugin.ps1
-    arguments: -UnrealEngine $(UnrealEngine) -PluginDir $(GraphicsToolsExamplesPluginDir)/GraphicsToolsExamples.uplugin -PackageOutDir $(GraphicsToolsExamplesBuildDir)
+    arguments: -UnrealEngine $(UnrealEngine) -PluginPath $(GraphicsToolsExamplesPluginDir)/GraphicsToolsExamples.uplugin -PackageOutDir $(GraphicsToolsExamplesBuildDir)
 
 - task: PowerShell@2
   displayName: 'Uninstall GraphicsTools from the engine'


### PR DESCRIPTION
- Add missing _EditorVersion.json_ so the build machine knows which engine version to use.
- Add missing forward declarations / includes causing a build failure on CI.
- Disable piplelines from running automatically on PR branches.
- Remove use of `$(Build.Repository.Name)` from pipelines as it prefixes organization name for GitHub repos.
- Typo in calls to `BuildPlugin.ps1`